### PR TITLE
Alternate "skip on windows" pattern for commander.js tests

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -3,6 +3,7 @@
 const { spawnSync } = require('child_process')
 const { readdirSync } = require('fs')
 const { extname, join } = require('path')
+const { isSkipped } = require('./utils.js');
 
 process.env.NODE_ENV = 'test';
 
@@ -12,14 +13,16 @@ readdirSync(__dirname).forEach((file) => {
     return;
   process.stdout.write(`\x1b[90m   ${file}\x1b[0m `);
   const result = spawnSync(process.argv0, [ join('test', file) ]);
-  if (result.stdout == 'SKIP ON WINDOWS') {
-    process.stdout.write('\x1b[36mSKIP ON WINDOWS\x1b[0m\n');
-  }
-  else if (result.status === 0) {
-    process.stdout.write('\x1b[36m✓\x1b[0m\n');
+  if (result.status === 0) {
+    if (isSkipped(result.stdout)) {
+      process.stdout.write('\x1b[33mSKIPPED\x1b[0m\n');
+    } else {
+      process.stdout.write('\x1b[36m✓\x1b[0m\n');
+    }
   } else {
     process.stdout.write('\x1b[31m✖\x1b[0m\n');
     console.error(result.stderr.toString('utf8'));
     process.exit(result.status);
   }
 })
+

--- a/test/test.command.executableSubcommand.signals.hup.js
+++ b/test/test.command.executableSubcommand.signals.hup.js
@@ -1,28 +1,26 @@
 var spawn = require('child_process').spawn,
   path = require('path'),
-  should = require('should');
+  should = require('should'),
+  utils = require('./utils.js');
+
+// Skip this test for Windows since signals are unsupported
+if (utils.skipOnWindows()) return;
 
 var bin = path.join(__dirname, './fixtures/pm');
 var proc = spawn(bin, ['listen'], {});
 
 var output = '';
-// Skip this test for Windows since signals are unsupported
-if (process.platform === 'win32') {
-  process.stdout.write('SKIP ON WINDOWS');
-  return;
-} else {
-  proc.stdout.on('data', function (data) {
-    output += data.toString();
-  });
-  
-  // Set a timeout to give 'proc' time to setup completely
-  setTimeout(function () {
-    proc.kill('SIGHUP');
-  
-    // Set another timeout to give 'prog' time to handle the signal
-    setTimeout(function() {
-      output.should.equal('SIGHUP\n');
-    }, 1000);
-  
-  }, 2000);
-}
+proc.stdout.on('data', function (data) {
+  output += data.toString();
+});
+
+// Set a timeout to give 'proc' time to setup completely
+setTimeout(function () {
+  proc.kill('SIGHUP');
+
+  // Set another timeout to give 'prog' time to handle the signal
+  setTimeout(function() {
+    output.should.equal('SIGHUP\n');
+  }, 1000);
+
+}, 2000);

--- a/test/test.command.executableSubcommand.signals.hup.js
+++ b/test/test.command.executableSubcommand.signals.hup.js
@@ -4,7 +4,10 @@ var spawn = require('child_process').spawn,
   utils = require('./utils.js');
 
 // Skip this test for Windows since signals are unsupported
-if (utils.skipOnWindows()) return;
+if (utils.isWindows()) {
+  utils.skip();
+  return;
+}
 
 var bin = path.join(__dirname, './fixtures/pm');
 var proc = spawn(bin, ['listen'], {});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,11 +1,12 @@
 
 const SKIPPED_MESSAGE = '**SKIPPED**';
 
-exports.skipOnWindows = function() {
-    if (process.platform == 'win32') {
-        process.stdout.write(SKIPPED_MESSAGE);
-        return true;
-    }
+exports.isWindows = function() {
+    return process.platform == 'win32';
+}
+
+exports.skip = function() {
+    process.stdout.write(SKIPPED_MESSAGE);
 }
 
 exports.isSkipped = function(stdout) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,13 @@
+
+const SKIPPED_MESSAGE = '**SKIPPED**';
+
+exports.skipOnWindows = function() {
+    if (process.platform == 'win32') {
+        process.stdout.write(SKIPPED_MESSAGE);
+        return true;
+    }
+}
+
+exports.isSkipped = function(stdout) {
+    return stdout.indexOf(SKIPPED_MESSAGE) == 0;
+}


### PR DESCRIPTION
@kaylangan - see if you like. I only updated one of the tests. This isolates the changes to just the start of the test and makes it less Windows-specific (even though tests are only skipped currently because the test is running on Windows).